### PR TITLE
feat: Add print button, separate tables, and editable titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,773 +5,157 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quadro de Horário</title>
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #f0f0f0;
-            color: #333;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            flex-direction: column;
-        }
-        h1 {
-            color: #000;
-            margin-bottom: 20px;
-        }
-        table {
-            border-collapse: collapse;
-            width: 95%;
-            max-width: 1400px;
-            margin: 20px auto;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-        }
-        th, td {
-            border: 1px solid black;
-            padding: 10px;
-            text-align: center;
-        }
-        thead th {
-            background-color: lightblue;
-            font-weight: bold;
-        }
-        .serie {
-            background-color: #dee2e6;
-            font-weight: bold;
-            vertical-align: middle;
-            width: 20px;
-        }
-        .serie span {
-            writing-mode: vertical-rl;
-            transform: rotate(180deg);
-            display: block;
-        }
-        tbody tr:nth-child(odd) {
-            background-color: #f8f9fa;
-        }
-        tbody tr:nth-child(even) {
-            background-color: #fff;
-        }
-        .intervalo {
-            background-color: lightgray;
-            font-weight: bold;
-            color: #000;
-        }
-        .intervalo-time {
-            font-weight: bold;
-        }
-        .printable-subject {
-            display: none;
-        }
-        .last-class-row td {
-            background-color: orange;
-        }
-        .header-container {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            width: 95%;
-            max-width: 1400px;
-            flex-wrap: wrap;
-        }
-        #manage-btn {
-            padding: 8px 16px;
-            font-size: 14px;
-            cursor: pointer;
-        }
-        .modal {
-          display: none;
-          position: fixed;
-          z-index: 1000;
-          left: 0;
-          top: 0;
-          width: 100%;
-          height: 100%;
-          overflow: auto;
-          background-color: rgba(0,0,0,0.4);
-        }
-        .modal-content {
-          background-color: #fefefe;
-          margin: 10% auto;
-          padding: 20px;
-          border: 1px solid #888;
-          width: 80%;
-          max-width: 700px;
-          border-radius: 8px;
-        }
-        .close-btn {
-          color: #aaa;
-          float: right;
-          font-size: 28px;
-          font-weight: bold;
-        }
-        .close-btn:hover,
-        .close-btn:focus {
-          color: black;
-          text-decoration: none;
-          cursor: pointer;
-        }
-        #allocation-form {
-          display: grid;
-          grid-template-columns: auto 1fr;
-          gap: 15px;
-          align-items: center;
-        }
-        #allocation-form h3, #allocations-list h3 {
-          grid-column: 1 / -1;
-        }
-        #allocation-form button {
-            grid-column: 1 / -1;
-            padding: 10px;
-            font-size: 16px;
-        }
+        body { font-family: Arial, sans-serif; background-color: #f0f0f0; color: #333; display: flex; justify-content: center; align-items: center; flex-direction: column; }
+        h1 { color: #000; margin-bottom: 10px; font-size: 18px; }
+        table { border-collapse: collapse; width: 95%; max-width: 1400px; margin: 15px auto; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        th, td { border: 1px solid black; padding: 5px; text-align: center; font-size: 9pt; }
+        thead th { background-color: lightblue; font-weight: bold; }
+        .serie { background-color: #dee2e6; font-weight: bold; vertical-align: middle; width: 20px; }
+        .serie span { writing-mode: vertical-rl; transform: rotate(180deg); display: block; }
+        tbody tr:nth-child(odd) { background-color: #f8f9fa; }
+        tbody tr:nth-child(even) { background-color: #fff; }
+        .intervalo { background-color: lightgray; font-weight: bold; color: #000; }
+        .intervalo-time { font-weight: bold; }
+        .printable-subject { display: none; }
+        .last-class-row td { background-color: orange; }
+        .header-container { display: flex; justify-content: space-between; align-items: center; width: 95%; max-width: 1400px; flex-wrap: wrap; margin-top: 20px; }
+        #manage-btn, #print-btn { padding: 8px 16px; font-size: 14px; cursor: pointer; margin-left: 10px; }
+        .modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+        .modal-content { background-color: #fefefe; margin: 10% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 700px; border-radius: 8px; }
+        .close-btn { color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer; }
+        #allocation-form { display: grid; grid-template-columns: auto 1fr; gap: 15px; align-items: center; }
+        #allocation-form h3, #allocations-list h3 { grid-column: 1 / -1; }
+        #allocation-form button { grid-column: 1 / -1; padding: 10px; font-size: 16px; }
         @media print {
-            .no-print {
-                display: none !important;
-            }
-            @page {
-                size: A4 landscape;
-                margin: 1cm;
-            }
-            body {
-                background-color: #fff;
-                -webkit-print-color-adjust: exact;
-                print-color-adjust: exact;
-            }
-            h1 {
-                font-size: 14pt;
-                margin-bottom: 10px;
-            }
-            table {
-                width: 100%;
-                font-size: 8pt;
-                page-break-inside: auto;
-            }
-            tr {
-                page-break-inside: avoid;
-                page-break-after: auto;
-            }
-            thead {
-                display: table-header-group;
-            }
-            th, td {
-                padding: 4px;
-                border: 1px solid #000;
-            }
-            .serie {
-                background-color: #dee2e6 !important;
-            }
-            .intervalo {
-                background-color: lightgray !important;
-            }
-            select {
-                display: none;
-            }
-            .printable-subject {
-                display: inline;
-            }
+            .no-print { display: none !important; }
+            @page { size: A4 landscape; margin: 0.5cm; }
+            body { background-color: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            h1 { font-size: 12pt; margin: 5px 0; }
+            table { width: 100%; font-size: 7pt; page-break-inside: auto; margin: 10px 0; box-shadow: none; }
+            tr { page-break-inside: avoid; page-break-after: auto; }
+            thead { display: table-header-group; }
+            th, td { padding: 3px; border: 1px solid #000; }
+            .serie { background-color: #dee2e6 !important; }
+            .intervalo { background-color: lightgray !important; }
+            select { display: none; }
+            .printable-subject { display: inline; }
         }
     </style>
 </head>
 <body>
-
-    <div class="header-container">
-        <h1>Horário do 6º ao 9º Ano – Manhã – Ano Letivo 2025 (01.09)</h1>
-        <button id="manage-btn" class="no-print">Gerenciar Aulas</button>
+    <div class="header-container no-print">
+        <div style="display: flex; gap: 20px;">
+            <button id="manage-btn">Gerenciar Aulas</button>
+            <button id="print-btn">Imprimir</button>
+        </div>
     </div>
 
+    <!-- Tabela Manhã - Fundamental -->
+    <div class="header-container">
+        <h1>Horário do 6º ao 9º Ano – Manhã – Ano Letivo <span id="title-year-1" contenteditable="true">2025</span> (<span id="title-date-1" contenteditable="true">01.09</span>)</h1>
+    </div>
     <table>
         <thead>
-            <tr>
-                <th>Sér.</th>
-                <th>Horário</th>
-                <th>Segunda-feira</th>
-                <th>Terça-feira</th>
-                <th>Quarta-feira</th>
-                <th>Quinta-feira</th>
-                <th>Sexta-feira</th>
-            </tr>
+            <tr> <th>Sér.</th> <th>Horário</th> <th>Segunda-feira</th> <th>Terça-feira</th> <th>Quarta-feira</th> <th>Quinta-feira</th> <th>Sexta-feira</th> </tr>
         </thead>
-        <tbody id="timetable-body">
-            <!-- 6º Ano -->
-            <tr data-grade="6º Ano - Manhã">
-                <td rowspan="6" class="serie"><span>6º Ano - Manhã</span></td>
-                <td>07:15 às 08:05</td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Bruna"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Bruna"></td>
-                <td class="subject-cell" data-subject="Artes/Josué"></td>
-                <td class="subject-cell" data-subject="Educ. Física/René"></td>
-            </tr>
-            <tr data-grade="6º Ano - Manhã">
-                <td>08:05 às 08:55</td>
-                <td class="subject-cell" data-subject="Educ. Física/René"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="Filosofia/Ednar Lima"></td>
-                <td class="subject-cell" data-subject="Mat./Geom./Lucas"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <tr data-grade="6º Ano - Manhã">
-                <td>08:55 às 09:45</td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-                <td class="subject-cell" data-subject="Mat./Geom./Lucas"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Bruna"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Bruna"></td>
-                <td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td>
-            </tr>
-            <tr data-grade="6º Ano - Manhã">
-                <td class="intervalo-time">09:45 às 10:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="6º Ano - Manhã">
-                <td>10:10 às 11:00</td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="6º Ano - Manhã">
-                <td>11:00 às 11:50</td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Inglês/Raul"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-                <td class="subject-cell" data-subject="Inglês/Raul"></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <!-- 7º Ano -->
-            <tr data-grade="7º Ano - Manhã">
-                <td rowspan="6" class="serie"><span>7º Ano - Manhã</span></td>
-                <td>07:15 às 08:05</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Bruna"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <tr data-grade="7º Ano - Manhã">
-                <td>08:05 às 08:55</td>
-                <td class="subject-cell" data-subject="Port./Gramática/Bruna"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-            </tr>
-            <tr data-grade="7º Ano - Manhã">
-                <td>08:55 às 09:45</td>
-                <td class="subject-cell" data-subject="Educ. Física/René"></td>
-                <td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td>
-                <td class="subject-cell" data-subject="Filosofia/Josué"></td>
-                <td class="subject-cell" data-subject="Mat./Geom./Lucas"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="7º Ano - Manhã">
-                <td class="intervalo-time">09:45 às 10:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="7º Ano - Manhã">
-                <td>10:10 às 11:00</td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Bruna"></td>
-                <td class="subject-cell" data-subject="Artes/Josué"></td>
-                <td class="subject-cell" data-subject="Educ. Física/René"></td>
-            </tr>
-            <tr data-grade="7º Ano - Manhã">
-                <td>11:00 às 11:50</td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-            </tr>
-            <!-- 8º Ano -->
-            <tr data-grade="8º Ano - Manhã">
-                <td rowspan="7" class="serie"><span>8º Ano - Manhã</span></td>
-                <td>07:15 às 08:05</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="8º Ano - Manhã">
-                <td>08:05 às 08:55</td>
-                <td class="subject-cell" data-subject="Educ. Física/René"></td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <tr data-grade="8º Ano - Manhã">
-                <td>08:55 às 09:45</td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Mat./Geom./Lucas"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <tr data-grade="8º Ano - Manhã">
-                <td class="intervalo-time">09:45 às 10:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="8º Ano - Manhã">
-                <td>10:10 às 11:00</td>
-                <td class="subject-cell" data-subject="Filosofia/Josué"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="8º Ano - Manhã">
-                <td>11:00 às 11:50</td>
-                <td class="subject-cell" data-subject="Port./Gramática/Bruna"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject="Artes/Josué"></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-             <tr data-grade="8º Ano - Manhã">
-                <td>11:50 às 12:40</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <!-- 9º Ano -->
-            <tr data-grade="9º Ano - Manhã">
-                <td rowspan="7" class="serie"><span>9º Ano - Manhã</span></td>
-                <td>07:15 às 08:05</td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Mat./Geom./Gustavo"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="9º Ano - Manhã">
-                <td>08:05 às 08:55</td>
-                <td class="subject-cell" data-subject="Filosofia/Josué"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Educ. Física/René"></td>
-            </tr>
-            <tr data-grade="9º Ano - Manhã">
-                <td>08:55 às 09:45</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-            </tr>
-            <tr data-grade="9º Ano - Manhã">
-                <td class="intervalo-time">09:45 às 10:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="9º Ano - Manhã">
-                <td>10:10 às 11:00</td>
-                <td class="subject-cell" data-subject="Educ. Física/René"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-            </tr>
-            <tr data-grade="9º Ano - Manhã">
-                <td>11:00 às 11:50</td>
-                <td class="subject-cell" data-subject="Port./Gramática/Bruna"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Bruna"></td>
-                <td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-             <tr data-grade="9º Ano - Manhã">
-                <td>11:50 às 12:40</td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject="Port./Redação/Bruna"></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject="Port./Geografia"></td>
-            </tr>
-            <!-- 1º Ano -->
-            <tr data-grade="1º Ano - Manhã">
-                <td rowspan="7" class="serie"><span>1º Ano - Manhã</span></td>
-                <td>07:15 às 08:05</td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Port./Literatura/Marcos"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-            </tr>
-            <tr data-grade="1º Ano - Manhã">
-                <td>08:05 às 08:55</td>
-                <td class="subject-cell" data-subject="História/Hiago"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-            </tr>
-            <tr data-grade="1º Ano - Manhã">
-                <td>08:55 às 09:45</td>
-                <td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td>
-            </tr>
-            <tr data-grade="1º Ano - Manhã">
-                <td class="intervalo-time">09:45 às 10:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="1º Ano - Manhã">
-                <td>10:10 às 11:00</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="História/Hiago"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Marcos"></td>
-            </tr>
-            <tr data-grade="1º Ano - Manhã">
-                <td>11:00 às 11:50</td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Marcos"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="1º Ano - Manhã">
-                <td>11:50 às 12:40</td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Marcos"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Marcos"></td>
-                <td class="subject-cell" data-subject="Filosofia/Socio./Josué"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-            </tr>
-            <!-- 2º Ano -->
-            <tr data-grade="2º Ano - Manhã">
-                <td rowspan="7" class="serie"><span>2º Ano - Manhã</span></td>
-                <td>07:15 às 08:05</td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-            </tr>
-            <tr data-grade="2º Ano - Manhã">
-                <td>08:05 às 08:55</td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Filosofia/Socio./Josué"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Marcos"></td>
-            </tr>
-            <tr data-grade="2º Ano - Manhã">
-                <td>08:55 às 09:45</td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Marcos"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Marcos"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-            </tr>
-            <tr data-grade="2º Ano - Manhã">
-                <td class="intervalo-time">09:45 às 10:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="2º Ano - Manhã">
-                <td>10:10 às 11:00</td>
-                <td class="subject-cell" data-subject="História/Hiago"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Marcos"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="História/Hiago"></td>
-            </tr>
-            <tr data-grade="2º Ano - Manhã">
-                <td>11:00 às 11:50</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-            </tr>
-            <tr data-grade="2º Ano - Manhã">
-                <td>11:50 às 12:40</td>
-                <td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-                <td class="subject-cell" data-subject="Port./Literatura/Marcos"></td>
-            </tr>
-            <!-- 3º Ano -->
-            <tr data-grade="3º Ano - Manhã">
-                <td rowspan="7" class="serie"><span>3º Ano - Manhã</span></td>
-                <td>07:15 às 08:05</td>
-                <td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Marcos"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td>
-            </tr>
-            <tr data-grade="3º Ano - Manhã">
-                <td>08:05 às 08:55</td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-                <td class="subject-cell" data-subject="Port./Literatura/Marcos"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Marcos"></td>
-                <td class="subject-cell" data-subject="História/Hiago"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-            </tr>
-            <tr data-grade="3º Ano - Manhã">
-                <td>08:55 às 09:45</td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Filosofia/Josué"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-            </tr>
-            <tr data-grade="3º Ano - Manhã">
-                <td class="intervalo-time">09:45 às 10:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="3º Ano - Manhã">
-                <td>10:10 às 11:00</td>
-                <td class="subject-cell" data-subject="Filosofia/Josué"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Marcos"></td>
-                <td class="subject-cell" data-subject="História/Hiago"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-            </tr>
-            <tr data-grade="3º Ano - Manhã">
-                <td>11:00 às 11:50</td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Biologia/Amanda"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Marcos"></td>
-            </tr>
-            <tr data-grade="3º Ano - Manhã">
-                <td>11:50 às 12:40</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
+        <tbody>
+            <tr data-grade="6º Ano - Manhã"><td rowspan="6" class="serie"><span>6º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Educ. Física/René"></td></tr>
+            <tr data-grade="6º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Filosofia/Ednar Lima"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="6º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td></tr>
+            <tr data-grade="6º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="6º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="6º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Raul"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Inglês/Raul"></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="7º Ano - Manhã"><td rowspan="6" class="serie"><span>7º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="7º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td></tr>
+            <tr data-grade="7º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="7º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="7º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Educ. Física/René"></td></tr>
+            <tr data-grade="7º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td></tr>
+            <tr data-grade="8º Ano - Manhã"><td rowspan="7" class="serie"><span>8º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="8º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="8º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="8º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="8º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="8º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="8º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Manhã"><td rowspan="7" class="serie"><span>9º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Geom./Gustavo"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="9º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Educ. Física/René"></td></tr>
+            <tr data-grade="9º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+            <tr data-grade="9º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="9º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td></tr>
+            <tr data-grade="9º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="Port./Geografia"></td></tr>
         </tbody>
     </table>
 
-    <h1>Horário do 6º ao 9º Ano - Tarde – Ano Letivo 2025 (19.08)</h1>
-
+    <!-- Tabela Manhã - Ensino Médio -->
+    <div class="header-container">
+        <h1>Horário do 1º ao 3º Ano – Manhã – Ano Letivo <span id="title-year-2" contenteditable="true">2025</span> - Ensino Médio (<span id="title-date-2" contenteditable="true">01.09</span>)</h1>
+    </div>
     <table>
         <thead>
-            <tr>
-                <th>Sér.</th>
-                <th>Horário</th>
-                <th>Segunda-feira</th>
-                <th>Terça-feira</th>
-                <th>Quarta-feira</th>
-                <th>Quinta-feira</th>
-                <th>Sexta-feira</th>
-            </tr>
+            <tr> <th>Sér.</th> <th>Horário</th> <th>Segunda-feira</th> <th>Terça-feira</th> <th>Quarta-feira</th> <th>Quinta-feira</th> <th>Sexta-feira</th> </tr>
         </thead>
-        <tbody id="timetable-body-tarde">
-            <!-- 6º Ano - Tarde -->
-            <tr data-grade="6º Ano - Tarde">
-                <td rowspan="6" class="serie"><span>6º Ano - Tarde</span></td>
-                <td>13:15 às 14:05</td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Filosofia/Ednar Lima"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="6º Ano - Tarde">
-                <td>14:05 às 14:55</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Socioemocional/Arielle"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Arielle"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <tr data-grade="6º Ano - Tarde">
-                <td>14:55 às 15:45</td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Arielle"></td>
-                <td class="subject-cell" data-subject="Port./Redação/Arielle"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-            </tr>
-            <tr data-grade="6º Ano - Tarde">
-                <td class="intervalo-time">15:45 às 16:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="6º Ano - Tarde">
-                <td>16:10 às 17:00</td>
-                <td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="6º Ano - Tarde">
-                <td>17:00 às 17:50</td>
-                <td class="subject-cell" data-subject="Artes/Josué"></td>
-                <td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Arielle"></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <!-- 7º Ano - Tarde -->
-            <tr data-grade="7º Ano - Tarde">
-                <td rowspan="6" class="serie"><span>7º Ano - Tarde</span></td>
-                <td>13:15 às 14:05</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="7º Ano - Tarde">
-                <td>14:05 às 14:55</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="7º Ano - Tarde">
-                <td>14:55 às 15:45</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="7º Ano - Tarde">
-                <td class="intervalo-time">15:45 às 16:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="7º Ano - Tarde">
-                <td>16:10 às 17:00</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="7º Ano - Tarde">
-                <td>17:00 às 17:50</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <!-- 8º Ano - Tarde -->
-            <tr data-grade="8º Ano - Tarde">
-                <td rowspan="7" class="serie"><span>8º Ano - Tarde</span></td>
-                <td>13:15 às 14:05</td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <tr data-grade="8º Ano - Tarde">
-                <td>14:05 às 14:55</td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Inglês/Tiago"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-            </tr>
-            <tr data-grade="8º Ano - Tarde">
-                <td>14:55 às 15:45</td>
-                <td class="subject-cell" data-subject="Artes/Josué"></td>
-                <td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td>
-                <td class="subject-cell" data-subject="Educ.Física/Renê"></td>
-                <td class="subject-cell" data-subject="Química/Amon"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="8º Ano - Tarde">
-                <td class="intervalo-time">15:45 às 16:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="8º Ano - Tarde">
-                <td>16:10 às 17:00</td>
-                <td class="subject-cell" data-subject="Ciências/Amon-rá"></td>
-                <td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td>
-                <td class="subject-cell" data-subject="Física/Anderson"></td>
-                <td class="subject-cell" data-subject="Socioemocional/Arielle"></td>
-                <td class="subject-cell" data-subject="História/Diógenes"></td>
-            </tr>
-            <tr data-grade="8º Ano - Tarde">
-                <td>17:00 às 17:50</td>
-                <td class="subject-cell" data-subject="Port./Redação/Arielle"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Arielle"></td>
-                <td class="subject-cell" data-subject="Geografia/André"></td>
-            </tr>
-            <tr data-grade="8º Ano - Tarde">
-                <td>17:50 às 18:40</td>
-                <td class="subject-cell" data-subject="Port./Redação/Arielle"></td>
-                <td class="subject-cell" data-subject="Filosofia/Josué"></td>
-                <td class="subject-cell" data-subject="Port./Gramática/Arielle"></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <!-- 9º Ano - Tarde -->
-            <tr data-grade="9º Ano - Tarde">
-                <td rowspan="7" class="serie"><span>9º Ano - Tarde</span></td>
-                <td>13:15 às 14:05</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="9º Ano - Tarde">
-                <td>14:05 às 14:55</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="9º Ano - Tarde">
-                <td>14:55 às 15:45</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="9º Ano - Tarde">
-                <td class="intervalo-time">15:45 às 16:05</td>
-                <td colspan="5" class="intervalo">INTERVALO</td>
-            </tr>
-            <tr data-grade="9º Ano - Tarde">
-                <td>16:10 às 17:00</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="9º Ano - Tarde">
-                <td>17:00 às 17:50</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
-            <tr data-grade="9º Ano - Tarde">
-                <td>17:50 às 18:40</td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-                <td class="subject-cell" data-subject=""></td>
-            </tr>
+        <tbody>
+            <tr data-grade="1º Ano - Manhã"><td rowspan="7" class="serie"><span>1º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Port./Literatura/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+            <tr data-grade="1º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td></tr>
+            <tr data-grade="1º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td></tr>
+            <tr data-grade="1º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="1º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td></tr>
+            <tr data-grade="1º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="1º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Filosofia/Socio./Josué"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+            <tr data-grade="2º Ano - Manhã"><td rowspan="7" class="serie"><span>2º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td></tr>
+            <tr data-grade="2º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Filosofia/Socio./Josué"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td></tr>
+            <tr data-grade="2º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+            <tr data-grade="2º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="2º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="História/Hiago"></td></tr>
+            <tr data-grade="2º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+            <tr data-grade="2º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Port./Literatura/Marcos"></td></tr>
+            <tr data-grade="3º Ano - Manhã"><td rowspan="7" class="serie"><span>3º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td></tr>
+            <tr data-grade="3º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Port./Literatura/Marcos"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+            <tr data-grade="3º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td></tr>
+            <tr data-grade="3º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="3º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+            <tr data-grade="3º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td></tr>
+            <tr data-grade="3º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+        </tbody>
+    </table>
+
+    <!-- Tabela Tarde - Fundamental -->
+    <div class="header-container">
+        <h1>Horário do 6º ao 9º Ano - Tarde – Ano Letivo <span id="title-year-3" contenteditable="true">2025</span> (<span id="title-date-3" contenteditable="true">19.08</span>)</h1>
+    </div>
+    <table>
+        <thead>
+            <tr> <th>Sér.</th> <th>Horário</th> <th>Segunda-feira</th> <th>Terça-feira</th> <th>Quarta-feira</th> <th>Quinta-feira</th> <th>Sexta-feira</th> </tr>
+        </thead>
+        <tbody>
+            <tr data-grade="6º Ano - Tarde"><td rowspan="6" class="serie"><span>6º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Filosofia/Ednar Lima"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="6º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Socioemocional/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="6º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+            <tr data-grade="6º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="6º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="6º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="7º Ano - Tarde"><td rowspan="6" class="serie"><span>7º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="7º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="7º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="7º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="7º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="7º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="8º Ano - Tarde"><td rowspan="7" class="serie"><span>8º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="8º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+            <tr data-grade="8º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="8º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="8º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Socioemocional/Arielle"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+            <tr data-grade="8º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            <tr data-grade="8º Ano - Tarde"><td>17:50 às 18:40</td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Tarde"><td rowspan="7" class="serie"><span>9º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+            <tr data-grade="9º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            <tr data-grade="9º Ano - Tarde"><td>17:50 às 18:40</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
         </tbody>
     </table>
 

--- a/main.js
+++ b/main.js
@@ -43,6 +43,35 @@ const classAllocations = {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+    // Title Persistence
+    const editableTitles = document.querySelectorAll('[contenteditable="true"]');
+
+    function saveTitles() {
+        const titles = {};
+        editableTitles.forEach(el => {
+            titles[el.id] = el.textContent;
+        });
+        localStorage.setItem('scheduleTitles', JSON.stringify(titles));
+    }
+
+    function loadTitles() {
+        const savedTitles = JSON.parse(localStorage.getItem('scheduleTitles'));
+        if (savedTitles) {
+            editableTitles.forEach(el => {
+                if (savedTitles[el.id]) {
+                    el.textContent = savedTitles[el.id];
+                }
+            });
+        }
+    }
+
+    editableTitles.forEach(el => {
+        el.addEventListener('blur', saveTitles);
+    });
+
+    loadTitles();
+
+
     let currentAllocations = loadAllocations();
     let uniqueSubjects = getUniqueSubjects(currentAllocations);
     assignSubjectColors(uniqueSubjects);
@@ -164,6 +193,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial Render
     renderAllSchedules();
+
+    // --- Print Logic ---
+    const printBtn = document.getElementById('print-btn');
+    printBtn.addEventListener('click', () => {
+        window.print();
+    });
 
     // --- Modal & Management Logic ---
     const modal = document.getElementById('management-modal');


### PR DESCRIPTION
This commit introduces the final set of requested features:
- A "Print" button has been added, which uses a print-specific stylesheet to format the schedules for A4 landscape printing.
- The HTML structure has been refactored to separate the High School classes into their own distinct table.
- The titles for each schedule table are now editable. The year and date can be clicked and changed by the user.
- These title changes are persisted in the browser's localStorage, so they are not lost on reload.