### PR TITLE
feat: Implement save/load for schedule state

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quadro de Horário</title>
+    <style>
+        body { font-family: Arial, sans-serif; background-color: #f0f0f0; color: #333; display: flex; justify-content: center; align-items: center; flex-direction: column; }
+        h1 { color: #000; margin-bottom: 10px; font-size: 18px; }
+        table { border-collapse: collapse; width: 95%; max-width: 1400px; margin: 15px auto; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        th, td { border: 1px solid black; padding: 5px; text-align: center; font-size: 9pt; }
+        thead th { background-color: lightblue; font-weight: bold; }
+        .serie { background-color: #dee2e6; font-weight: bold; vertical-align: middle; width: 20px; }
+        .serie span { writing-mode: vertical-rl; transform: rotate(180deg); display: block; }
+        tbody tr:nth-child(odd) { background-color: #f8f9fa; }
+        tbody tr:nth-child(even) { background-color: #fff; }
+        .intervalo { background-color: lightgray; font-weight: bold; color: #000; }
+        .intervalo-time { font-weight: bold; }
+        .printable-subject { display: none; }
+        .last-class-row td { background-color: orange; }
+        .header-container { display: flex; justify-content: space-between; align-items: center; width: 95%; max-width: 1400px; flex-wrap: wrap; margin-top: 20px; }
+        #manage-btn, #print-btn { padding: 8px 16px; font-size: 14px; cursor: pointer; margin-left: 10px; }
+        .modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+        .modal-content { background-color: #fefefe; margin: 10% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 700px; border-radius: 8px; }
+        .close-btn { color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer; }
+        #allocation-form { display: grid; grid-template-columns: auto 1fr; gap: 15px; align-items: center; }
+        #allocation-form h3, #allocations-list h3 { grid-column: 1 / -1; }
+        #allocation-form button { grid-column: 1 / -1; padding: 10px; font-size: 16px; }
+        @media print {
+            .printable-page {
+                page-break-after: always;
+            }
+            .no-print { display: none !important; }
+            @page { size: A4 landscape; margin: 0.5cm; }
+            body { background-color: #fff; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            h1 { font-size: 12pt; margin: 5px 0; }
+            table { width: 100%; font-size: 7pt; page-break-inside: auto; margin: 10px 0; box-shadow: none; }
+            tr { page-break-inside: avoid; page-break-after: auto; }
+            thead { display: table-header-group; }
+            th, td { padding: 3px; border: 1px solid #000; }
+            .serie { background-color: #dee2e6 !important; }
+            .intervalo { background-color: lightgray !important; }
+            select { display: none; }
+            .printable-subject { display: inline; }
+        }
+    </style>
+</head>
+<body>
+    <div class="header-container no-print">
+        <div style="display: flex; gap: 20px;">
+            <button id="manage-btn">Gerenciar Aulas</button>
+            <button id="save-schedule-btn">Salvar Horário</button>
+            <button id="print-btn">Imprimir</button>
+        </div>
+    </div>
+
+    <div class="printable-page">
+        <!-- Tabela Manhã - Fundamental -->
+        <div class="header-container">
+            <h1>Horário do 6º ao 9º Ano – Manhã – Ano Letivo <span id="title-year-1" contenteditable="true">2025</span> (<span id="title-date-1" contenteditable="true">01.09</span>)</h1>
+        </div>
+        <table>
+            <thead>
+                <tr> <th>Sér.</th> <th>Horário</th> <th>Segunda-feira</th> <th>Terça-feira</th> <th>Quarta-feira</th> <th>Quinta-feira</th> <th>Sexta-feira</th> </tr>
+            </thead>
+            <tbody>
+                <tr data-grade="6º Ano - Manhã"><td rowspan="6" class="serie"><span>6º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Educ. Física/René"></td></tr>
+                <tr data-grade="6º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Filosofia/Ednar Lima"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="6º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td></tr>
+                <tr data-grade="6º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="6º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="6º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Raul"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Inglês/Raul"></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="7º Ano - Manhã"><td rowspan="6" class="serie"><span>7º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="7º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td></tr>
+                <tr data-grade="7º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="7º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="7º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Educ. Física/René"></td></tr>
+                <tr data-grade="7º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td></tr>
+                <tr data-grade="8º Ano - Manhã"><td rowspan="7" class="serie"><span>8º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="8º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="8º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Geom./Lucas"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="8º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="8º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="8º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Mat./Álgebra/Lucas"></td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="8º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Manhã"><td rowspan="7" class="serie"><span>9º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Geom./Gustavo"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="9º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Educ. Física/René"></td></tr>
+                <tr data-grade="9º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="História/Diógenes"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+                <tr data-grade="9º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="9º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Educ. Física/René"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td></tr>
+                <tr data-grade="9º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Port./Gramática/Bruna"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Bruna"></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject="Sócio. Emocional/Bruna"></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="Port./Redação/Bruna"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="Port./Geografia"></td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="printable-page">
+        <!-- Tabela Manhã - Ensino Médio -->
+        <div class="header-container">
+            <h1>Horário do 1º ao 3º Ano – Manhã – Ano Letivo <span id="title-year-2" contenteditable="true">2025</span> - Ensino Médio (<span id="title-date-2" contenteditable="true">01.09</span>)</h1>
+        </div>
+        <table>
+            <thead>
+                <tr> <th>Sér.</th> <th>Horário</th> <th>Segunda-feira</th> <th>Terça-feira</th> <th>Quarta-feira</th> <th>Quinta-feira</th> <th>Sexta-feira</th> </tr>
+            </thead>
+            <tbody>
+                <tr data-grade="1º Ano - Manhã"><td rowspan="7" class="serie"><span>1º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Port./Literatura/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+                <tr data-grade="1º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td></tr>
+                <tr data-grade="1º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td></tr>
+                <tr data-grade="1º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="1º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td></tr>
+                <tr data-grade="1º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="1º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Filosofia/Socio./Josué"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+                <tr data-grade="2º Ano - Manhã"><td rowspan="7" class="serie"><span>2º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td></tr>
+                <tr data-grade="2º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Filosofia/Socio./Josué"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td></tr>
+                <tr data-grade="2º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+                <tr data-grade="2º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="2º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="História/Hiago"></td></tr>
+                <tr data-grade="2º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+                <tr data-grade="2º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Port./Literatura/Marcos"></td></tr>
+                <tr data-grade="3º Ano - Manhã"><td rowspan="7" class="serie"><span>3º Ano - Manhã</span></td><td>07:15 às 08:05</td><td class="subject-cell" data-subject="Artes/Proj.deVida/Josué"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Port./Interp.Textual/Marcos"></td></tr>
+                <tr data-grade="3º Ano - Manhã"><td>08:05 às 08:55</td><td class="subject-cell" data-subject="Geografia/André"></td><td class="subject-cell" data-subject="Port./Literatura/Marcos"></td><td class="subject-cell" data-subject="Port./Redação/Marcos"></td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+                <tr data-grade="3º Ano - Manhã"><td>08:55 às 09:45</td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td></tr>
+                <tr data-grade="3º Ano - Manhã"><td class="intervalo-time">09:45 às 10:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="3º Ano - Manhã"><td>10:10 às 11:00</td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td><td class="subject-cell" data-subject="História/Hiago"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td></tr>
+                <tr data-grade="3º Ano - Manhã"><td>11:00 às 11:50</td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Biologia/Amanda"></td><td class="subject-cell" data-subject="Port./Gramática/Marcos"></td></tr>
+                <tr data-grade="3º Ano - Manhã"><td>11:50 às 12:40</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="printable-page">
+        <!-- Tabela Tarde - Fundamental -->
+        <div class="header-container">
+            <h1>Horário do 6º ao 9º Ano - Tarde – Ano Letivo <span id="title-year-3" contenteditable="true">2025</span> (<span id="title-date-3" contenteditable="true">19.08</span>)</h1>
+        </div>
+        <table>
+            <thead>
+                <tr> <th>Sér.</th> <th>Horário</th> <th>Segunda-feira</th> <th>Terça-feira</th> <th>Quarta-feira</th> <th>Quinta-feira</th> <th>Sexta-feira</th> </tr>
+            </thead>
+            <tbody>
+                <tr data-grade="6º Ano - Tarde"><td rowspan="6" class="serie"><span>6º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Filosofia/Ednar Lima"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="6º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Socioemocional/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="6º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+                <tr data-grade="6º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="6º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="6º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="7º Ano - Tarde"><td rowspan="6" class="serie"><span>7º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="7º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="7º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="7º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="7º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="7º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="8º Ano - Tarde"><td rowspan="7" class="serie"><span>8º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="8º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Inglês/Tiago"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td></tr>
+                <tr data-grade="8º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject="Artes/Josué"></td><td class="subject-cell" data-subject="Mat./Geometria/Gustavo"></td><td class="subject-cell" data-subject="Educ.Física/Renê"></td><td class="subject-cell" data-subject="Química/Amon"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="8º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="8º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject="Ciências/Amon-rá"></td><td class="subject-cell" data-subject="Port./Int.Textual/Arielle"></td><td class="subject-cell" data-subject="Física/Anderson"></td><td class="subject-cell" data-subject="Socioemocional/Arielle"></td><td class="subject-cell" data-subject="História/Diógenes"></td></tr>
+                <tr data-grade="8º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Mat./Álgebra/Gustavo"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject="Geografia/André"></td></tr>
+                <tr data-grade="8º Ano - Tarde"><td>17:50 às 18:40</td><td class="subject-cell" data-subject="Port./Redação/Arielle"></td><td class="subject-cell" data-subject="Filosofia/Josué"></td><td class="subject-cell" data-subject="Port./Gramática/Arielle"></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Tarde"><td rowspan="7" class="serie"><span>9º Ano - Tarde</span></td><td>13:15 às 14:05</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Tarde"><td>14:05 às 14:55</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Tarde"><td>14:55 às 15:45</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Tarde"><td class="intervalo-time">15:45 às 16:05</td><td colspan="5" class="intervalo">INTERVALO</td></tr>
+                <tr data-grade="9º Ano - Tarde"><td>16:10 às 17:00</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Tarde"><td>17:00 às 17:50</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+                <tr data-grade="9º Ano - Tarde"><td>17:50 às 18:40</td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td><td class="subject-cell" data-subject=""></td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div id="management-modal" class="modal no-print">
+      <div class="modal-content">
+        <span class="close-btn">&times;</span>
+        <h2>Gerenciar Alocação de Aulas</h2>
+        <form id="allocation-form">
+          <h3>Adicionar / Editar Alocação</h3>
+          <label for="subject-input">Matéria/Professor:</label>
+          <input type="text" id="subject-input" placeholder="Ex: Artes/Josué" required>
+          <label for="grade-select">Turma:</label>
+          <select id="grade-select" required></select>
+          <label for="count-input">Número de Aulas:</label>
+          <input type="number" id="count-input" min="0" value="1" required>
+          <button type="submit">Salvar Alocação</button>
+        </form>
+        <hr>
+        <h3>Alocações Atuais</h3>
+        <div id="allocations-list"></div>
+      </div>
+    </div>
+
+    <script src="main.js" defer></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,333 @@
+const subjectColors = {};
+const colorPalette = [
+    '#FFADAD', '#FFD6A5', '#FDFFB6', '#CAFFBF', '#9BF6FF', '#A0C4FF', '#BDB2FF', '#FFC6FF',
+    '#FFC8DD', '#FFD8BE', '#FFFAC0', '#D4F0C0', '#B0E0E6', '#B4D8E7', '#C6D8FF', '#E1D4FF'
+];
+
+function getUniqueSubjects(allocations) {
+    const allSubjects = new Set([""]); // Start with empty option
+    for (const grade in allocations) {
+        for (const subject in allocations[grade]) {
+            allSubjects.add(subject);
+        }
+    }
+    return [...allSubjects].sort();
+}
+
+function assignSubjectColors(subjects) {
+    let colorIndex = 0;
+    // Clear existing colors
+    for (const key in subjectColors) {
+        delete subjectColors[key];
+    }
+    subjects.forEach(subject => {
+        if (subject) {
+            subjectColors[subject] = colorPalette[colorIndex % colorPalette.length];
+            colorIndex++;
+        }
+    });
+}
+
+const classAllocations = {
+    "6º Ano - Manhã": { "Port./Interp.Textual/Bruna": 2, "Port./Gramática/Bruna": 2, "Port./Redação/Bruna": 2, "Artes/Josué": 1, "Educ. Física/René": 2, "Mat./Álgebra/Lucas": 3, "Filosofia/Ednar Lima": 1, "Mat./Geom./Lucas": 2, "História/Diógenes": 2, "Sócio. Emocional/Bruna": 1, "Geografia/André": 2, "Ciências/Amon-rá": 2, "Inglês/Raul": 2, },
+    "7º Ano - Manhã": { "Inglês/Tiago": 2, "Mat./Álgebra/Lucas": 3, "História/Diógenes": 2, "Port./Redação/Bruna": 1, "Port./Gramática/Bruna": 2, "Ciências/Amon-rá": 3, "Port./Interp.Textual/Bruna": 3, "Educ. Física/René": 2, "Sócio. Emocional/Bruna": 1, "Filosofia/Josué": 1, "Mat./Geom./Lucas": 1, "Geografia/André": 2, "Artes/Josué": 1, },
+    "8º Ano - Manhã": { "Inglês/Tiago": 2, "Química/Amon": 2, "Física/Anderson": 2, "Mat./Álgebra/Lucas": 2, "Geografia/André": 3, "Educ. Física/René": 1, "Ciências/Amon-rá": 2, "Sócio. Emocional/Bruna": 1, "História/Diógenes": 3, "Mat./Geom./Lucas": 1, "Filosofia/Josué": 1, "Port./Interp.Textual/Bruna": 2, "Port./Gramática/Bruna": 1, "Artes/Josué": 1, },
+    "9º Ano - Manhã": { "Geografia/André": 2, "Inglês/Tiago": 2, "Mat./Geom./Gustavo": 1, "Mat./Geometria/Gustavo": 2, "Filosofia/Josué": 1, "Port./Interp.Textual/Bruna": 2, "Química/Amon": 2, "Educ. Física/René": 2, "Mat./Álgebra/Gustavo": 3, "História/Diógenes": 1, "Biologia/Amanda": 2, "Física/Anderson": 2, "Port./Gramática/Bruna": 1, "Port./Redação/Bruna": 2, "Sócio. Emocional/Bruna": 1, "Port./Geografia": 1, },
+    "1º Ano - Manhã": { "Química/Amon": 3, "Port./Literatura/Marcos": 1, "Física/Anderson": 3, "Biologia/Amanda": 3, "História/Hiago": 2, "Mat./Álgebra/Gustavo": 3, "Educ.Física/Renê": 2, "Artes/Proj.deVida/Josué": 1, "Mat./Geometria/Gustavo": 2, "Port./Interp.Textual/Marcos": 1, "Inglês/Tiago": 2, "Port./Gramática/Marcos": 2, "Port./Redação/Marcos": 2, "Geografia/André": 2, "Filosofia/Socio./Josué": 1, },
+    "2º Ano - Manhã": { "Mat./Álgebra/Gustavo": 3, "Educ.Física/Renê": 2, "Biologia/Amanda": 3, "Mat./Geometria/Gustavo": 2, "Química/Amon": 3, "Física/Anderson": 3, "Filosofia/Socio./Josué": 1, "Port./Gramática/Marcos": 2, "Geografia/André": 2, "Port./Redação/Marcos": 2, "História/Hiago": 2, "Inglês/Tiago": 2, "Port./Interp.Textual/Marcos": 1, "Artes/Proj.deVida/Josué": 1, "Port./Literatura/Marcos": 1, },
+    "3º Ano - Manhã": { "Artes/Proj.deVida/Josué": 1, "Física/Anderson": 3, "Port./Redação/Marcos": 2, "Química/Amon": 3, "Port./Interp.Textual/Marcos": 1, "Geografia/André": 2, "Port./Literatura/Marcos": 1, "História/Hiago": 2, "Biologia/Amanda": 3, "Mat./Geometria/Gustavo": 2, "Mat./Álgebra/Gustavo": 3, "Filosofia/Josué": 2, "Port./Gramática/Marcos": 2, "Educ.Física/Renê": 1, "Inglês/Tiago": 2, },
+    "6º Ano - Tarde": { "Ciências/Amon-rá": 2, "Mat./Álgebra/Gustavo": 3, "Filosofia/Ednar Lima": 1, "Mat./Geometria/Gustavo": 2, "Geografia/André": 2, "Inglês/Tiago": 2, "Socioemocional/Arielle": 1, "Port./Redação/Arielle": 2, "História/Diógenes": 2, "Port./Gramática/Arielle": 2, "Educ.Física/Renê": 2, "Port./Int.Textual/Arielle": 2, "Artes/Josué": 1, },
+    "7º Ano - Tarde": {},
+    "8º Ano - Tarde": { "Inglês/Tiago": 2, "Port./Int.Textual/Arielle": 2, "Mat./Álgebra/Gustavo": 3, "Química/Amon": 2, "História/Diógenes": 2, "Ciências/Amon-rá": 2, "Física/Anderson": 2, "Mat./Geometria/Gustavo": 2, "Educ.Física/Renê": 2, "Artes/Josué": 1, "Geografia/André": 2, "Socioemocional/Arielle": 1, "Port./Redação/Arielle": 2, "Port./Gramática/Arielle": 2, "Filosofia/Josué": 1, },
+    "9º Ano - Tarde": {},
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Title Persistence
+    const editableTitles = document.querySelectorAll('[contenteditable="true"]');
+
+    function saveTitles() {
+        const titles = {};
+        editableTitles.forEach(el => {
+            titles[el.id] = el.textContent;
+        });
+        localStorage.setItem('scheduleTitles', JSON.stringify(titles));
+    }
+
+    function loadTitles() {
+        const savedTitles = JSON.parse(localStorage.getItem('scheduleTitles'));
+        if (savedTitles) {
+            editableTitles.forEach(el => {
+                if (savedTitles[el.id]) {
+                    el.textContent = savedTitles[el.id];
+                }
+            });
+        }
+    }
+
+    editableTitles.forEach(el => {
+        el.addEventListener('blur', saveTitles);
+    });
+
+    loadTitles();
+
+
+    let currentAllocations = loadAllocations();
+    let uniqueSubjects = getUniqueSubjects(currentAllocations);
+    assignSubjectColors(uniqueSubjects);
+
+    const gradeSelects = new Map();
+
+    function renderAllSchedules() {
+        gradeSelects.clear();
+        const gradeRows = document.querySelectorAll('tr[data-grade]');
+        const savedSchedule = JSON.parse(localStorage.getItem('savedScheduleState')) || {};
+
+        gradeRows.forEach((row, rowIndex) => {
+            const gradeName = row.dataset.grade;
+            if (!gradeSelects.has(gradeName)) {
+                gradeSelects.set(gradeName, []);
+            }
+            const cells = row.querySelectorAll('.subject-cell');
+            cells.forEach((cell, cellIndex) => {
+                // Clear previous content
+                cell.innerHTML = '';
+
+                const select = document.createElement('select');
+                const printableSpan = document.createElement('span');
+                printableSpan.className = 'printable-subject';
+                const initialSubject = cell.dataset.subject.replace(/\s\/\s/g, '/').trim();
+
+                uniqueSubjects = getUniqueSubjects(currentAllocations);
+                assignSubjectColors(uniqueSubjects);
+
+                uniqueSubjects.forEach(subject => {
+                    const option = document.createElement('option');
+                    option.value = subject;
+                    option.textContent = subject || '---------';
+                    select.appendChild(option);
+                });
+
+                const savedValueKey = `${gradeName}-${rowIndex}-${cellIndex}`;
+                const savedValue = savedSchedule[savedValueKey];
+
+                if (savedValue !== undefined) {
+                    select.value = savedValue;
+                    printableSpan.textContent = savedValue;
+                } else {
+                    select.value = initialSubject;
+                    printableSpan.textContent = initialSubject;
+                }
+
+                select.addEventListener('change', () => {
+                    printableSpan.textContent = select.value;
+                    applyCellColor(cell, select.value);
+                    updateGradeSelects(gradeName);
+                });
+
+                cell.appendChild(select);
+                cell.appendChild(printableSpan);
+                gradeSelects.get(gradeName).push(select);
+                applyCellColor(cell, initialSubject);
+            });
+        });
+
+        for (const [gradeName, selects] of gradeSelects.entries()) {
+            updateGradeSelects(gradeName);
+        }
+        highlightLastClasses();
+    }
+
+    function applyCellColor(targetCell, subject) {
+        if (subject && subjectColors[subject]) {
+            targetCell.style.backgroundColor = subjectColors[subject];
+        } else {
+            targetCell.style.backgroundColor = '';
+        }
+    }
+
+    function updateGradeSelects(gradeName) {
+        const selectsInGrade = gradeSelects.get(gradeName);
+        const allocations = currentAllocations[gradeName] || {};
+        const currentCounts = {};
+        selectsInGrade.forEach(s => {
+            if (s.value) {
+                currentCounts[s.value] = (currentCounts[s.value] || 0) + 1;
+            }
+        });
+        selectsInGrade.forEach(select => {
+            for (const option of select.options) {
+                if (!option.value) continue;
+                const subject = option.value;
+                const allocationCount = allocations[subject] || 99; // Allow unscheduled subjects to be added
+                const currentCount = currentCounts[subject] || 0;
+                if (subject === select.value) {
+                    option.disabled = false;
+                    continue;
+                }
+                if (currentCount >= allocationCount) {
+                    option.disabled = true;
+                } else {
+                    option.disabled = false;
+                }
+            }
+        });
+    }
+
+    function highlightLastClasses() {
+        const allGradeRows = document.querySelectorAll('tr[data-grade]');
+        const gradeRowGroups = {};
+        allGradeRows.forEach(row => {
+            const gradeName = row.dataset.grade;
+            if (!gradeRowGroups[gradeName]) {
+                gradeRowGroups[gradeName] = [];
+            }
+            gradeRowGroups[gradeName].push(row);
+        });
+        for (const gradeName in gradeRowGroups) {
+            const rows = gradeRowGroups[gradeName];
+            let lastClassRow = null;
+            for (let i = rows.length - 1; i >= 0; i--) {
+                if (!rows[i].querySelector('.intervalo')) {
+                    lastClassRow = rows[i];
+                    break;
+                }
+            }
+            if (lastClassRow) {
+                lastClassRow.classList.add('last-class-row');
+            }
+        }
+    }
+
+    // Initial Render
+    renderAllSchedules();
+
+    // --- Print Logic ---
+    const printBtn = document.getElementById('print-btn');
+    printBtn.addEventListener('click', () => {
+        window.print();
+    });
+
+    // --- Schedule Save Logic ---
+    const saveScheduleBtn = document.getElementById('save-schedule-btn');
+
+    function saveSchedule() {
+        const scheduleState = {};
+        const rows = document.querySelectorAll('tr[data-grade]');
+        rows.forEach((row, rowIndex) => {
+            const gradeName = row.dataset.grade;
+            const cells = row.querySelectorAll('.subject-cell');
+            cells.forEach((cell, cellIndex) => {
+                const select = cell.querySelector('select');
+                if (select) {
+                    const key = `${gradeName}-${rowIndex}-${cellIndex}`;
+                    scheduleState[key] = select.value;
+                }
+            });
+        });
+        localStorage.setItem('savedScheduleState', JSON.stringify(scheduleState));
+        alert('Horário salvo com sucesso!');
+    }
+
+    saveScheduleBtn.addEventListener('click', saveSchedule);
+
+
+    // --- Modal & Management Logic ---
+    const modal = document.getElementById('management-modal');
+    const manageBtn = document.getElementById('manage-btn');
+    const closeBtn = document.querySelector('.close-btn');
+    const gradeSelect = document.getElementById('grade-select');
+    const allocationsListDiv = document.getElementById('allocations-list');
+    const allocationForm = document.getElementById('allocation-form');
+
+    function loadAllocations() {
+        const saved = localStorage.getItem('classAllocations');
+        if (saved) {
+            return JSON.parse(saved);
+        }
+        return classAllocations; // Default
+    }
+
+    function saveAllocations() {
+        localStorage.setItem('classAllocations', JSON.stringify(currentAllocations));
+    }
+
+    function populateAllocationsList() {
+        allocationsListDiv.innerHTML = '';
+        const sortedGrades = Object.keys(currentAllocations).sort();
+        for (const gradeName of sortedGrades) {
+            const gradeDiv = document.createElement('div');
+            gradeDiv.innerHTML = `<h4>${gradeName}</h4>`;
+            const subjectList = document.createElement('ul');
+            const subjectsInGrade = currentAllocations[gradeName];
+            const sortedSubjects = Object.keys(subjectsInGrade).sort();
+            for (const subject of sortedSubjects) {
+                const count = subjectsInGrade[subject];
+                const listItem = document.createElement('li');
+                listItem.innerHTML = `<span>${subject}: ${count} aula(s)</span> <button class="delete-btn" data-grade="${gradeName}" data-subject="${subject}">Excluir</button>`;
+                subjectList.appendChild(listItem);
+            }
+            gradeDiv.appendChild(subjectList);
+            allocationsListDiv.appendChild(gradeDiv);
+        }
+    }
+
+    allocationForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const subjectInput = document.getElementById('subject-input');
+        const grade = gradeSelect.value;
+        const count = parseInt(document.getElementById('count-input').value, 10);
+        const subject = subjectInput.value.trim();
+
+        if (!subject || !grade || isNaN(count)) {
+            alert('Por favor, preencha todos os campos corretamente.');
+            return;
+        }
+
+        if (!currentAllocations[grade]) {
+            currentAllocations[grade] = {};
+        }
+        currentAllocations[grade][subject] = count;
+
+        saveAllocations();
+        populateAllocationsList(); // Refresh the list in the modal
+        renderAllSchedules(); // Re-render the main timetable
+        allocationForm.reset();
+        subjectInput.focus();
+    });
+
+    allocationsListDiv.addEventListener('click', (e) => {
+        if (e.target.classList.contains('delete-btn')) {
+            const grade = e.target.dataset.grade;
+            const subject = e.target.dataset.subject;
+            if (confirm(`Tem certeza que deseja excluir "${subject}" da turma "${grade}"?`)) {
+                delete currentAllocations[grade][subject];
+                saveAllocations();
+                populateAllocationsList();
+                renderAllSchedules();
+            }
+        }
+    });
+
+    const gradeNames = Object.keys(currentAllocations).sort();
+    gradeSelect.innerHTML = '';
+    gradeNames.forEach(name => {
+        const option = document.createElement('option');
+        option.value = name;
+        option.textContent = name;
+        gradeSelect.appendChild(option);
+    });
+
+    manageBtn.onclick = () => {
+        populateAllocationsList();
+        modal.style.display = 'block';
+    };
+    closeBtn.onclick = () => {
+        modal.style.display = 'none';
+    };
+    window.onclick = (event) => {
+        if (event.target == modal) {
+            modal.style.display = 'none';
+        }
+    };
+});


### PR DESCRIPTION
This commit adds the ability for users to save their modified schedule.

- A "Salvar Horário" (Save Schedule) button has been added.
- When clicked, the state of all dropdowns in the timetable is saved to localStorage.
- When the page is loaded, it checks for a saved state and applies it, restoring the user's previous modifications.
- This fixes a major usability issue where changes were lost on reload.
- Also includes a bugfix for the allocation logic, allowing subjects with a '0' allocation to be selected.